### PR TITLE
update jsonpath docs to include negative indices

### DIFF
--- a/docs/user-guide/jsonpath.md
+++ b/docs/user-guide/jsonpath.md
@@ -7,6 +7,8 @@ And we add three functions in addition to the original JSONPath syntax:
 1. The `$` operator is optional since the expression always start from the root object by default.
 2. We can use `""` to quote text inside JSONPath expression.
 3. We can use `range` operator to iterate list.
+4. We can use negative slice indices to step backwards through a list.
+  - Negative indices do not "wrap around" a list. They are valid as long as `-index + listLenght >= 0`.
 
 The result object is printed as its String() function.
 


### PR DESCRIPTION
Related PR: https://github.com/kubernetes/kubernetes/pull/48778

Adds mention of negative index use (support for these is added in the linked PR).