### PR TITLE
Typo add ";"

### DIFF
--- a/docs/concepts/containers/images.md
+++ b/docs/concepts/containers/images.md
@@ -51,7 +51,7 @@ you can do one of the following:
 - enable the [AlwaysPullImages](/docs/admin/admission-controllers/#alwayspullimages) admission controller.
 -->
 - 设置容器的 `imagePullPolicy` 为 `Always`；
-- 使用 `:latest` 作为镜像的标签去使用
+- 使用 `:latest` 作为镜像的标签去使用；
 - 开启 [AlwaysPullImages](/docs/admin/admission-controllers/#alwayspullimages) 准入控制器。
 
 <!--


### PR DESCRIPTION
If there are ";" for end of sentences  in a list, all of the sentences should use it except the last sentence. But in line 54, there is no ";" at the end.