### PR TITLE
Typo fix a clerical error in list-all-running-container-images.md

### DIFF
--- a/docs/tasks/access-application-cluster/list-all-running-container-images.md
+++ b/docs/tasks/access-application-cluster/list-all-running-container-images.md
@@ -71,7 +71,7 @@ uniq -c
 The above command will recursively return all fields named `image`
 for all items returned.
 -->
-上面对命令会对所有对返回项递归地取出 `image` 字段并计数。
+上面的命令会对所有对返回项递归地取出 `image` 字段并计数。
 
 <!--
 As an alternative, it is possible to use the absolute path to the image


### PR DESCRIPTION
74行：一个笔误。“上面对命令会对所有...”-》“上面的命令会对所有...”
否则语句不通。