### PR TITLE
Update calico-network-policy.md

### DIFF
--- a/docs/tasks/administer-cluster/calico-network-policy.md
+++ b/docs/tasks/administer-cluster/calico-network-policy.md
@@ -1,14 +1,14 @@
 ---
 approvers:
 - caseydavenport
-title: 为了 NetworkPolicy 使用 Calico
+title: 使用 Calico 来提供 NetworkPolicy
 ---
 
 <!--
 This page shows how to use Calico for NetworkPolicy.
 -->
 {% capture overview %}
-本页展示怎么样为了 NetworkPolicy 使用 Calico
+本页展示怎么样使用 Calico 来提供 NetworkPolicy
 {% endcapture %}
 
 <!--


### PR DESCRIPTION
标题和文首包含的“为了 NetworkPolice 使用 Calico”翻译的太拗口了。
建议参考一下cilium-network-policy.md中的翻译方式：“使用 Cilium 来提供 NetworkPolicy”