### PR TITLE
Typo fix in configure-access-multiple-clusters.md

### DIFF
--- a/docs/tasks/access-application-cluster/configure-access-multiple-clusters.md
+++ b/docs/tasks/access-application-cluster/configure-access-multiple-clusters.md
@@ -57,9 +57,9 @@ Create a directory named `config-exercise`. In your
 ## 定义集群、用户和上下文
 
 假设用户有两个集群，一个用于正式开发工作（development），一个用于其它临时用途（scratch）。
-在 `development` 集群中，前端开发者在名为 `frontend` 的名字空间下工作，
-存储开发者在名为 `storage` 的名字空间下工作。 在 `scratch` 集群中，
-开发人员可能在默认名字空间下工作，也可能视情况创建附加的名字空间。 访问开发集群需要通过证书进行认证。 访问其它临时用途的集群需要通过用户名和密码进行认证。
+在 `development` 集群中，前端开发者在名为 `frontend` 的命名空间下工作，
+存储开发者在名为 `storage` 的命名空间下工作。 在 `scratch` 集群中，
+开发人员可能在默认命名空间下工作，也可能视情况创建附加的命名空间。 访问开发集群需要通过证书进行认证。 访问其它临时用途的集群需要通过用户名和密码进行认证。
 
 创建名为 `config-exercise` 的目录。 在
 `config-exercise` 目录中，创建名为 `config-demo` 的文件，其内容为：
@@ -188,8 +188,8 @@ user to access the `frontend` namespace of the `development` cluster.
 
 Set the current context:
 -->
-每个上下文包含三部分（集群、用户和名字空间），例如，
-`dev-frontend` 上下文表明：使用 `developer` 用户的凭证来访问 `development` 集群的 `frontend` 名字空间。
+每个上下文包含三部分（集群、用户和命名空间），例如，
+`dev-frontend` 上下文表明：使用 `developer` 用户的凭证来访问 `development` 集群的 `frontend` 命名空间。
 
 设置当前上下文：
 
@@ -205,7 +205,7 @@ the credentials of the user listed in the `dev-frontend` context.
 To see only the configuration information associated with
 the current context, use the `--minify` flag.
 -->
-现在当输入 `kubectl` 命令时，相应动作会应用于 `dev-frontend` 上下文中所列的集群和名字空间，同时，命令会使用 `dev-frontend` 上下文中所列用户的凭证。
+现在当输入 `kubectl` 命令时，相应动作会应用于 `dev-frontend` 上下文中所列的集群和命名空间，同时，命令会使用 `dev-frontend` 上下文中所列用户的凭证。
 
 使用 `--minify` 参数，来查看与当前上下文相关联的配置信息。
 
@@ -262,7 +262,7 @@ listed in the `exa-scratch` context.
 View configuration associated with the new current context, `exp-scratch`.
 
 -->
-现在用户 `kubectl` 下达的任何命令都将应用于 `scratch` 集群的默认名字空间。 同时，命令会使用 `exp-scratch` 上下文中所列用户的凭证。
+现在用户 `kubectl` 下达的任何命令都将应用于 `scratch` 集群的默认命名空间。 同时，命令会使用 `exp-scratch` 上下文中所列用户的凭证。
 
 查看更新后的当前上下文 `exp-scratch` 相关的配置：
 
@@ -276,7 +276,7 @@ Finally, suppose you want to work for a while in the `storage` namespace of the
 
 Change the current context to `dev-storage`:
 -->
-最后，假设用户希望在 `development` 集群中的 `storage` 名字空间下工作一段时间。
+最后，假设用户希望在 `development` 集群中的 `storage` 命名空间下工作一段时间。
 
 将当前上下文更改为 `dev-storage`：
 


### PR DESCRIPTION
namespace 一般翻译为命名空间，本项目中其他地方也都是这么翻译的。
但在本文中翻译为名字空间，建议修改。