### PR TITLE
Typo fix in service-access-application-cluster.md

### DIFF
--- a/docs/tasks/access-application-cluster/service-access-application-cluster.md
+++ b/docs/tasks/access-application-cluster/service-access-application-cluster.md
@@ -138,7 +138,7 @@ provides load balancing for an application that has two running instances.
 
 -->
 
-## 为在两个 pod 中运行的应用程序创建 service
+## 为在两个 pod 中运行的应用程序创建 Service
 
 1. 在集群中运行 Hello World 应用程序：
 


### PR DESCRIPTION
正文中的Service都是首字母大写以示特指，建议141行也保持一致。