### PR TITLE
fix：yaml文件格式，不需要双引号

### DIFF
--- a/docs/concepts/configuration/assign-pod-node.md
+++ b/docs/concepts/configuration/assign-pod-node.md
@@ -419,9 +419,10 @@ tolerations:
 
 ```yaml
 tolerations: 
-- key: "key"
-  operator: "Exists"
-  effect: "NoSchedule"
+- key: key
+  operator: Exists
+  value: value
+  effect: NoSchedule
 ```
 
 <!--


### PR DESCRIPTION
fix：yaml文件格式，不需要双引号
文中还有下面多处不符合yaml文件格式
另外少了value: value这一行