### PR TITLE
fix:line156 "anti-affinity" should be"Anti-affinity"

### DIFF
--- a/docs/concepts/configuration/assign-pod-node.md
+++ b/docs/concepts/configuration/assign-pod-node.md
@@ -153,7 +153,7 @@ with a standard set of labels. As of Kubernetes v1.4 these labels are
 <!--
 ## Affinity and anti-affinity
 -->
-## 亲和性（Affinity）和反亲和性（anti-affinity）
+## 亲和性（Affinity）和反亲和性（Anti-affinity）
 
 <!--
 `nodeSelector` provides a very simple way to constrain pods to nodes with particular labels. The affinity/anti-affinity


### PR DESCRIPTION
反亲和性是专有名词与亲和性保持一致，应为Anti-affinity