### PR TITLE
翻译错误：用户账号准入控制器（Service account admission controller）

### DIFF
--- a/docs/admin/service-accounts-admin.md
+++ b/docs/admin/service-accounts-admin.md
@@ -77,7 +77,7 @@ Three separate components cooperate to implement the automation around service a
 -->
 服务账号的自动化由三个独立的组件共同配合实现：
 
-  - 用户账号准入控制器（Service account admission controller）
+  - 服务账号准入控制器（Service account admission controller）
   - 令牌控制器（Token controller）
   - 服务账号控制器（Service account controller）
 


### PR DESCRIPTION
Line80: 用户账号准入控制器（Service account admission controller）
此处应该时服务账号准入控制器