### PR TITLE
Typo fix：词语位置错误

### DIFF
--- a/docs/tasks/access-application-cluster/service-access-application-cluster.md
+++ b/docs/tasks/access-application-cluster/service-access-application-cluster.md
@@ -208,7 +208,7 @@ provides load balancing for an application that has two running instances.
 
 7. 获取正在运行 Hello World 应用程序的 Pod 的其中一个节点的 public IP 地址。如何得到这个地址取决于您的集群设置。例如，如果您使用 Minikube，可以通过运行 `kubectl cluster-info` 查看节点地址。如果您是使用 Google Compute Engine 实例，可以使用 `gcloud compute instances list` 命令查看您的公共地址节点。
 
-8. 在您选择的节点上，在您的节点端口上例如创建允许 TCP 流量的防火墙规则，如果您的服务 NodePort 值为 31568，创建防火墙规则，允许端口 31568 上的TCP流量。
+8. 在您选择的节点上，在您的节点端口上创建允许 TCP 流量的防火墙规则，例如：如果您的服务 NodePort 值为 31568，创建防火墙规则，允许端口 31568 上的TCP流量。
 
 9. 使用节点地址和节点端口访问 Hello World 应用程序：
 


### PR DESCRIPTION
在您的节点端口上例如创建允许 TCP 流量的防火墙规则，如果您的服务 NodePort 值为 31568，
参考原英文描述，建议修改为：
在您的节点端口上创建允许 TCP 流量的防火墙规则，例如：如果您的服务 NodePort 值为 31568，