### PR TITLE
fix:"中断预算"change to "PodDisruptionBudget"

### DIFF
--- a/docs/tasks/administer-cluster/safely-drain-node.md
+++ b/docs/tasks/administer-cluster/safely-drain-node.md
@@ -12,7 +12,9 @@ title: 遵循应用中断预算安全移除节点
 This page shows how to safely drain a machine, respecting the application-level
 disruption SLOs you have specified using PodDisruptionBudget.
 -->
-本页展示如何遵循使用 PodDisruptionBudget 指定的应用级中断预算安全地移除节点。
+本页展示如何遵循使用 PodDisruptionBudget 指定的PodDisruptionBudget安全地移除节点。
+
+
 {% endcapture %}
 
 {% capture prerequisites %}


### PR DESCRIPTION
line15 ,"PodDisruptionBudget"为专有名词，不能译为“中断预算”