### PR TITLE
Delete extra headlines

### DIFF
--- a/content/cn/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/content/cn/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -107,9 +107,7 @@ web-1     1/1       Running   0         18s
 
 请注意在 `web-0` Pod 处于 [Running和Ready](/docs/user-guide/pod-states) 状态后 `web-1` Pod 才会被启动。
 
-<!-
-## Pods in a StatefulSet
--->
+
 ## StatefulSet 中的 Pod
 
 

--- a/content/cn/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/content/cn/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -107,8 +107,8 @@ web-1     1/1       Running   0         18s
 
 请注意在 `web-0` Pod 处于 [Running和Ready](/docs/user-guide/pod-states) 状态后 `web-1` Pod 才会被启动。
 
-<!-
-Pods in a StatefulSet
+<!--
+## Pods in a StatefulSet
 -->
 
 ## StatefulSet 中的 Pod

--- a/content/cn/docs/tutorials/stateful-application/basic-stateful-set.md
+++ b/content/cn/docs/tutorials/stateful-application/basic-stateful-set.md
@@ -107,6 +107,9 @@ web-1     1/1       Running   0         18s
 
 请注意在 `web-0` Pod 处于 [Running和Ready](/docs/user-guide/pod-states) 状态后 `web-1` Pod 才会被启动。
 
+<!-
+Pods in a StatefulSet
+-->
 
 ## StatefulSet 中的 Pod
 


### PR DESCRIPTION
The headline `Pods in a StatefulSet ` is equal to `StatefulSet 中的 Pod` but the `StatefulSet 中的 Pod`  has appeared in the title below.
The original PR:<https://github.com/kubernetes/website/pull/10095>